### PR TITLE
Add matchedWildcard flag to BaseRobotRules

### DIFF
--- a/src/main/java/crawlercommons/robots/BaseRobotRules.java
+++ b/src/main/java/crawlercommons/robots/BaseRobotRules.java
@@ -44,6 +44,7 @@ public abstract class BaseRobotRules implements Serializable {
 
     private long _crawlDelay = UNSET_CRAWL_DELAY;
     private boolean _deferVisits = false;
+    protected boolean _matchedWildcard = false;
     private LinkedHashSet<String> _sitemaps;
 
     public BaseRobotRules() {
@@ -81,6 +82,25 @@ public abstract class BaseRobotRules implements Serializable {
      */
     public void setDeferVisits(boolean deferVisits) {
         _deferVisits = deferVisits;
+    }
+
+    /**
+     * Returns whether the wildcard user agent (*) was matched.
+     *
+     * @return true if the wildcard user agent was matched; false otherwise.
+     */
+
+    public boolean isMatchedWildcard() {
+        return _matchedWildcard;
+    }
+
+    /**
+     * Sets whether the wildcard user agent (*) was matched.
+     *
+     * @param matchedWildcard true if the wildcard user agent was matched; false otherwise.
+     */
+    public void setMatchedWildcard(boolean matchedWildcard) {
+        this._matchedWildcard = matchedWildcard;
     }
 
     /** Add sitemap URL to rules if not a duplicate */

--- a/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
@@ -261,6 +261,7 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
 
         public void setMatchedWildcard(boolean matchedWildcard) {
             _matchedWildcard = matchedWildcard;
+            _curRules.setMatchedWildcard(matchedWildcard);
         }
 
         public boolean isAddingRules() {

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -1401,6 +1401,25 @@ public class SimpleRobotRulesParserTest {
         assertFalse(rules.isAllowed("https://example.org/path/index.html"));
     }
 
+    @Test
+    void testMatchedWildcard() {
+        final String robotsTxt =
+                "User-agent: *" + CRLF //
+                        + "Allow: /" + CRLF //
+                        + "User-agent: anybot" + CRLF //
+                        + "Disallow: /search";
+
+        BaseRobotRules rules1 = createRobotRules("foobot", robotsTxt);
+        BaseRobotRules rules2 = createRobotRules("anybot", robotsTxt);
+
+        assertTrue(rules1.isMatchedWildcard());
+        assertFalse(rules2.isMatchedWildcard());
+        assertTrue(rules1.isAllowed("https://www.example.com/search"));
+        assertFalse(rules2.isAllowed("https://www.example.com/search"));
+        assertTrue(rules1.isAllowed("https://www.example.com/home"));
+        assertTrue(rules2.isAllowed("https://www.example.com/home"));
+    }
+
     private byte[] readFile(String filename) throws Exception {
         byte[] bigBuffer = new byte[100000];
         InputStream is = SimpleRobotRulesParserTest.class.getResourceAsStream(filename);


### PR DESCRIPTION
This PR adds a getter/setter for the isMatchedWildcard flag to the BaseRobotRules class. This allows the client be able to tell whether the passed in user agent was explicitly matched, or it defaulted to the wildcard user agent.

This is useful for reporting, where we can distinguish between which hosts matched a specific rule vs a wildcard.